### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-storefrontcloud.yml
+++ b/.github/workflows/deploy-storefrontcloud.yml
@@ -26,7 +26,7 @@ jobs:
           npx @shopware-pwa/cli@latest init --ci --devMode --shopwareDomainsAllowList=${{ env.RELEASE_URL }} --shopwareDomainsAllowList=${{ env.RELEASE_URL }}/de
           yarn build
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: shopware-pwa-storefrontcloud-io/vue-storefront:${{ github.sha }}
           registry: registry.storefrontcloud.io

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -399,7 +399,7 @@ jobs:
           npx @shopware-pwa/cli@canary init --u ${{ secrets.SHOPWARE_ADMIN_USER }} --p ${{ secrets.SHOPWARE_ADMIN_PASSWORD }} --shopwareDomainsAllowList=${{ env.PWA_HOST }} --shopwareDomainsAllowList=${{ env.PWA_HOST }}/germany --ci --devMode --stage canary
           yarn build
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: shopware-pwa-storefrontcloud-io/vue-storefront:${{ github.sha }}
           registry: registry.storefrontcloud.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore